### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 setup(
     name="hoymiles-wifi",
     packages=["hoymiles_wifi", "hoymiles_wifi.protobuf"],
-    install_requires=["protobuf", "crcmod"],
+    install_requires=["protobuf>=5.29.3", "crcmod"],
     version="0.4.0",
     description="A python library for interfacing with the Hoymiles DTUs and the HMS-XXXXW-2T series of micro-inverters using protobuf messages.",
     author="suaveolent",


### PR DESCRIPTION
Added minimum protobuf requirement in order to ensure compatibility with Home Assistant’s protobuf version installed.

See https://github.com/suaveolent/ha-hoymiles-wifi/discussions/113